### PR TITLE
AppVeyor fix

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -25,7 +25,7 @@ environment:
   CURL_RETRY: '10'
   CURL_RETRY_DELAY: '10'
   PIP_RETRY: '10'
-  CODECOV_VERSION: '2.1.7'
+  CODECOV_VERSION: '2.1.13'
 
   matrix:
     - APPVEYOR_BUILD_WORKER_IMAGE: 'Visual Studio 2019'


### PR DESCRIPTION
Upgrade of codecov Python package to the latest version (2.1.7 -> 2.1.13), because the old one was removed from PyPI.